### PR TITLE
:bug: data rescaling on attenuation coefficient

### DIFF
--- a/xcom/xcom.py
+++ b/xcom/xcom.py
@@ -54,7 +54,7 @@ def calculate_attenuation(material: Material, energy: np.ndarray = None):
         # atom_weight[gr] = atom_weight[amu] / AVOGADRO
         atom_weigth = MaterialFactory.get_element_mass(element)
         for name in data.dtype.names:
-            data[name] /= _AVOGADRO / atom_weigth
+            if name != "energy": data[name] *= (_AVOGADRO / atom_weigth)
         return data
     elif len(material) > 1:
         atom_weights_amu = MaterialFactory.get_elements_mass_list(material.elements_by_Z)


### PR DESCRIPTION
The cross sections were divided by a rescaling factor while it should have been multiplied by this same factor, and the energy was also rescaled by this factor, which is incorrect.